### PR TITLE
Kyne0658

### DIFF
--- a/KK_SkinEffects/SkinEffectGameController.cs
+++ b/KK_SkinEffects/SkinEffectGameController.cs
@@ -19,12 +19,12 @@ namespace KK_SkinEffects
 
         protected override void OnPeriodChange(Cycle.Type period)
         {
-            ClearFluidState();
+            ClearCharaState();
         }
 
         protected override void OnDayChange(Cycle.Week day)
         {
-            ClearFluidState();
+            ClearCharaState();
             _disableDeflowering.Clear();
         }
 
@@ -84,7 +84,7 @@ namespace KK_SkinEffects
             }
         }
 
-        private static void ClearFluidState()
+        private static void ClearCharaState()
         {
             foreach (var heroine in _persistentCharaState.Keys)
             {

--- a/KK_SkinEffects/SkinEffectsController.cs
+++ b/KK_SkinEffects/SkinEffectsController.cs
@@ -467,6 +467,9 @@ namespace KK_SkinEffects
 
         private void UpdateClothingState()
         {
+            if (this.ChaControl.fileParam.sex == 1)
+                // VisibleSonAlways causes bottomless girls to have penises
+                this.ChaControl.chaFile.status.visibleSonAlways = false;
             if (_clothingState != null)
                 this.ChaControl.chaFile.status.clothesState = _clothingState;
         }

--- a/KK_SkinEffects/SkinEffectsController.cs
+++ b/KK_SkinEffects/SkinEffectsController.cs
@@ -8,6 +8,7 @@ using KKAPI.Maker;
 using KKAPI.Studio;
 using KoiSkinOverlayX;
 using UnityEngine;
+using System.Reflection;
 
 namespace KK_SkinEffects
 {
@@ -18,6 +19,9 @@ namespace KK_SkinEffects
         private int _sweatLevel;
         private int _tearLevel;
         private int _droolLevel;
+        private byte[] _clothingState;
+        private bool[] _accessoryState;
+        private byte[] _siruState;
         private KoiSkinOverlayController _ksox;
 
         public int BloodLevel
@@ -87,6 +91,45 @@ namespace KK_SkinEffects
                     _droolLevel = value;
                     UpdateDroolTexture();
                 }
+            }
+        }
+
+        public byte[] ClothingState
+        {
+            get => _clothingState;
+            set
+            {
+                if (_clothingState != value)
+                {
+                    _clothingState = value;
+                    UpdateClothingState();
+                }
+            }
+        }
+        public bool[] AccessoryState
+        {
+            get => _accessoryState;
+            set
+            {
+                if (_accessoryState != value)
+                {
+                    _accessoryState = value;
+                    UpdateAccessoryState();
+                }
+
+            }
+        }
+        public byte[] SiruState
+        {
+            get => _siruState;
+            set
+            {
+                if (_siruState != value)
+                {
+                    _siruState = value;
+                    UpdateSiruState();
+                }
+
             }
         }
 
@@ -221,7 +264,7 @@ namespace KK_SkinEffects
             data.data[nameof(FragileVag)] = FragileVag;
 
             if (currentGameMode == GameMode.Studio)
-                WriteFluidState(data.data);
+                WriteCharaState(data.data);
 
             SetExtendedData(data);
         }
@@ -254,7 +297,7 @@ namespace KK_SkinEffects
             {
                 case GameMode.Studio:
                     // Get the state set in the character state menu
-                    ApplyFluidState(data?.data);
+                    ApplyCharaState(data?.data);
                     break;
 
                 case GameMode.MainGame:
@@ -263,12 +306,12 @@ namespace KK_SkinEffects
                     break;
 
                 default:
-                    ClearFluidState(true);
+                    ClearCharaState(true);
                     break;
             }
         }
 
-        public bool ClearFluidState(bool refreshTextures = false)
+        public bool ClearCharaState(bool refreshTextures = false)
         {
             var needsUpdate = _ksox.AdditionalTextures.RemoveAll(x => ReferenceEquals(x.Tag, this)) > 0;
 
@@ -277,6 +320,8 @@ namespace KK_SkinEffects
             _sweatLevel = 0;
             _tearLevel = 0;
             _droolLevel = 0;
+            _clothingState = _siruState = null;
+            _accessoryState = null;
 
             if (refreshTextures)
                 UpdateAllTextures();
@@ -284,9 +329,9 @@ namespace KK_SkinEffects
             return needsUpdate;
         }
 
-        public void ApplyFluidState(IDictionary<string, object> dataDict)
+        public void ApplyCharaState(IDictionary<string, object> dataDict)
         {
-            var needsUpdate = ClearFluidState();
+            var needsUpdate = ClearCharaState();
             if (dataDict != null && dataDict.Count > 0)
             {
                 if (dataDict.TryGetValue(nameof(BukkakeLevel), out var obj)) _bukkakeLevel = (int)obj;
@@ -294,12 +339,18 @@ namespace KK_SkinEffects
                 if (dataDict.TryGetValue(nameof(BloodLevel), out var obj3)) _bloodLevel = (int)obj3;
                 if (dataDict.TryGetValue(nameof(TearLevel), out var obj4)) _tearLevel = (int)obj4;
                 if (dataDict.TryGetValue(nameof(DroolLevel), out var obj5)) _droolLevel = (int)obj5;
+                if (dataDict.TryGetValue(nameof(ClothingState), out var obj6)) _clothingState = (byte[])obj6;
+                if (dataDict.TryGetValue(nameof(AccessoryState), out var obj7)) _accessoryState = (bool[])obj7;
+                if (dataDict.TryGetValue(nameof(SiruState), out var obj8)) _siruState = (byte[])obj8;
 
                 UpdateWetTexture(false);
                 UpdateBldTexture(false);
                 UpdateCumTexture(false);
                 UpdateDroolTexture(false);
                 UpdateTearTexture(false);
+                UpdateClothingState();
+                UpdateAccessoryState();
+                UpdateSiruState();
 
                 needsUpdate = true;
             }
@@ -308,13 +359,16 @@ namespace KK_SkinEffects
                 UpdateAllTextures();
         }
 
-        public void WriteFluidState(IDictionary<string, object> dataDict)
+        public void WriteCharaState(IDictionary<string, object> dataDict)
         {
             dataDict[nameof(BukkakeLevel)] = BukkakeLevel;
             dataDict[nameof(SweatLevel)] = SweatLevel;
             dataDict[nameof(BloodLevel)] = BloodLevel;
             dataDict[nameof(TearLevel)] = TearLevel;
             dataDict[nameof(DroolLevel)] = DroolLevel;
+            dataDict[nameof(ClothingState)] = this.ChaControl.chaFile.status.clothesState.Clone();
+            dataDict[nameof(AccessoryState)] = this.ChaControl.chaFile.status.showAccessory.Clone();
+            dataDict[nameof(SiruState)] = this.ChaControl.chaFile.status.siruLv.Clone();
         }
 
         protected override void Start()
@@ -407,5 +461,44 @@ namespace KK_SkinEffects
                     _ksox.UpdateTexture(TexType.FaceOver);
             }
         }
+
+        private void UpdateClothingState()
+        {
+            if (_clothingState != null)
+                this.ChaControl.chaFile.status.clothesState = _clothingState;
+        }
+
+        private void UpdateAccessoryState()
+        {
+            if (_accessoryState != null)
+                this.ChaControl.chaFile.status.showAccessory = _accessoryState;
+
+        }
+
+        private void UpdateSiruState()
+        {
+            if (_siruState != null)
+            {
+                var cha = this.ChaControl;
+                foreach (ChaFileDefine.SiruParts s in Enum.GetValues(typeof(ChaFileDefine.SiruParts)))
+                {
+                    cha.SetSiruFlags(s, _siruState[(int)s]);
+                }
+
+                bool hiPoly = cha.hiPoly;
+                // Set hiPoly on Overworld
+                PropertyInfo property = typeof(ChaControl).GetProperty("hiPoly");
+                property.DeclaringType.GetProperty("Property");
+                property.GetSetMethod(true).Invoke(cha, new object[] { true });
+
+                // Trigger Semen update
+                typeof(ChaControl).GetMethod("UpdateSiru", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(cha, new object[] { true });
+
+                // Reset
+                property.GetSetMethod(true).Invoke(cha, new object[] { hiPoly });
+            }
+        }
+
+
     }
 }

--- a/KK_SkinEffects/SkinEffectsController.cs
+++ b/KK_SkinEffects/SkinEffectsController.cs
@@ -323,6 +323,9 @@ namespace KK_SkinEffects
             _clothingState = _siruState = null;
             _accessoryState = null;
 
+            // Siru needs special removal
+            RemoveSiru();
+
             if (refreshTextures)
                 UpdateAllTextures();
 
@@ -477,26 +480,37 @@ namespace KK_SkinEffects
 
         private void UpdateSiruState()
         {
+            var cha = this.ChaControl;
             if (_siruState != null)
             {
-                var cha = this.ChaControl;
                 foreach (ChaFileDefine.SiruParts s in Enum.GetValues(typeof(ChaFileDefine.SiruParts)))
                 {
                     cha.SetSiruFlags(s, _siruState[(int)s]);
                 }
-
-                bool hiPoly = cha.hiPoly;
-                // Set hiPoly on Overworld
-                PropertyInfo property = typeof(ChaControl).GetProperty("hiPoly");
-                property.DeclaringType.GetProperty("Property");
-                property.GetSetMethod(true).Invoke(cha, new object[] { true });
-
-                // Trigger Semen update
-                typeof(ChaControl).GetMethod("UpdateSiru", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(cha, new object[] { true });
-
-                // Reset
-                property.GetSetMethod(true).Invoke(cha, new object[] { hiPoly });
             }
+
+            bool hiPoly = cha.hiPoly;
+            // Set hiPoly on Overworld
+            PropertyInfo property = typeof(ChaControl).GetProperty("hiPoly");
+            property.DeclaringType.GetProperty("Property");
+            property.GetSetMethod(true).Invoke(cha, new object[] { true });
+
+            // Trigger Semen update
+            typeof(ChaControl).GetMethod("UpdateSiru", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(cha, new object[] { true });
+
+            // Reset
+            property.GetSetMethod(true).Invoke(cha, new object[] { hiPoly });
+        }
+
+        private void RemoveSiru()
+        {
+            var cha = this.ChaControl;
+            foreach (ChaFileDefine.SiruParts s in Enum.GetValues(typeof(ChaFileDefine.SiruParts)))
+            {
+                cha.SetSiruFlags(s, 0);
+            }
+            this.UpdateSiruState();
+
         }
 
 

--- a/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
+++ b/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
@@ -161,6 +161,7 @@ namespace KK_SkinEffects
                 1, // Toilet
                 2, // Shower
                 4, // H Solo
+                25, // Embarrassment
                 26, // Lez
                 27, // Lez Partner
             });
@@ -184,7 +185,8 @@ namespace KK_SkinEffects
                 // Put clothes on when the latest action is not in the set.
                 if (n >= 2 && (_replaceClothesActions.Contains(actions[n - 2])) && actions[n - 2] != actions[n - 1])
                 {
-                    npc.heroine.chaCtrl.SetClothesStateAll(0);
+                    if (actions[n - 1] != 25) // Changing Clothes -> Embarrassment
+                        npc.heroine.chaCtrl.SetClothesStateAll(0);
                     if (actions[n - 1] == 2) //shower
                     {
                         npc.heroine.chaCtrl.GetComponent<SkinEffectsController>().ClearCharaState(true);

--- a/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
+++ b/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
@@ -157,12 +157,12 @@ namespace KK_SkinEffects
 
             private static HashSet<int> _replaceClothesActions = new HashSet<int>(new int[]
             {
-                0x0, // Change Clothes
-                0x1, // Toilet
-                0x2, // Shower
-                0x4, // H Solo
-                0x26, // Lez
-                0x27, // Lez Partner
+                0, // Change Clothes
+                1, // Toilet
+                2, // Shower
+                4, // H Solo
+                26, // Lez
+                27, // Lez Partner
             });
 
             [HarmonyPrefix]
@@ -175,7 +175,7 @@ namespace KK_SkinEffects
                 int n = actions.Length;
 
                 // 17 (change mind) seems to happen when redirected by the player while desire is something else
-                if (actions[n - 1] == 0x17)
+                if (actions[n - 1] == 23)
                 {
                     return;
                 }

--- a/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
+++ b/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
@@ -158,6 +158,7 @@ namespace KK_SkinEffects
             private static HashSet<int> _replaceClothesActions = new HashSet<int>(new int[]
             {
                 0, // Change Clothes
+                1, // Toilet
                 2, // Shower
                 4, // H Solo
                 26, // Lez
@@ -178,6 +179,10 @@ namespace KK_SkinEffects
                 if (n >= 2 && (_replaceClothesActions.Contains(actions[n-2])) && actions[n-2] != actions[n-1])
                 {
                     npc.heroine.chaCtrl.SetClothesStateAll(0);
+                    if (actions[n - 1] == 2) //shower
+                    {
+                        npc.heroine.chaCtrl.GetComponent<SkinEffectsController>().ClearCharaState(true);
+                    }
                 }
             }
 

--- a/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
+++ b/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
@@ -174,6 +174,12 @@ namespace KK_SkinEffects
                 int[] actions = GetLastActions(__instance, npc);
                 int n = actions.Length;
 
+                // 17 (change mind) seems to happen when redirected by the player while desire is something else
+                if (actions[n-1] == 17)
+                {
+                    return;
+                }
+
                 // Multiple change clothes actions can be queued up.
                 // Put clothes on when the latest action is not in the set.
                 if (n >= 2 && (_replaceClothesActions.Contains(actions[n-2])) && actions[n-2] != actions[n-1])

--- a/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
+++ b/KK_SkinEffects/SkinEffectsMgr.Hooks.cs
@@ -157,12 +157,12 @@ namespace KK_SkinEffects
 
             private static HashSet<int> _replaceClothesActions = new HashSet<int>(new int[]
             {
-                0, // Change Clothes
-                1, // Toilet
-                2, // Shower
-                4, // H Solo
-                26, // Lez
-                27, // Lez Partner
+                0x0, // Change Clothes
+                0x1, // Toilet
+                0x2, // Shower
+                0x4, // H Solo
+                0x26, // Lez
+                0x27, // Lez Partner
             });
 
             [HarmonyPrefix]
@@ -175,14 +175,14 @@ namespace KK_SkinEffects
                 int n = actions.Length;
 
                 // 17 (change mind) seems to happen when redirected by the player while desire is something else
-                if (actions[n-1] == 17)
+                if (actions[n - 1] == 0x17)
                 {
                     return;
                 }
 
                 // Multiple change clothes actions can be queued up.
                 // Put clothes on when the latest action is not in the set.
-                if (n >= 2 && (_replaceClothesActions.Contains(actions[n-2])) && actions[n-2] != actions[n-1])
+                if (n >= 2 && (_replaceClothesActions.Contains(actions[n - 2])) && actions[n - 2] != actions[n - 1])
                 {
                     npc.heroine.chaCtrl.SetClothesStateAll(0);
                     if (actions[n - 1] == 2) //shower


### PR DESCRIPTION
New features:
1. During a conversation, changes to clothing/accessories using ClothingStateMenu will persist into overworld and HScenes.
2. After an HScene, clothing, accessories, and fluid states will persist into overworld and future conversations.

It seems pretty stable. Some minor bugs I've seen:
1. chaFile.chaStatus.showAccessory can fail to include all accessories (due to MoreAccessories?), so sometimes not all accessory states are persisted
2. Janitor/closet talk scene completely resets the state, but only during the talk scenes. Maybe because a brand new ChaControl is created?