### PR TITLE
Misc bugfixes

### DIFF
--- a/KK_SkinEffects/Hooks.PersistClothes.cs
+++ b/KK_SkinEffects/Hooks.PersistClothes.cs
@@ -130,7 +130,7 @@ namespace KK_SkinEffects
                     if (previousAction == 2)
                     {
                         // After shower clear everything
-                        effectsController.ClearCharaState(true);
+                        effectsController.ClearCharaState(true, true);
                         SkinEffectGameController.SavePersistData(npc.heroine, effectsController);
                     }
                     else if (currentAction == 2)

--- a/KK_SkinEffects/Hooks.PersistClothes.cs
+++ b/KK_SkinEffects/Hooks.PersistClothes.cs
@@ -57,8 +57,15 @@ namespace KK_SkinEffects
                         controller.AccessoryState = null;
 
                         var heroine = __instance.GetHeroine();
+
                         if (heroine != null)
-                            SkinEffectGameController.SavePersistData(heroine, controller);
+                        {
+                            // If leaving a special scene (e.g. lunch), maintain clothes from scene.
+                            if (heroine.charaBase is NPC npc && npc.IsExitingScene())
+                                return false;
+                            else
+                                SkinEffectGameController.SavePersistData(heroine, controller);
+                        }
                     }
 
                     return true;
@@ -114,6 +121,9 @@ namespace KK_SkinEffects
                 if (previousAction != currentAction && replaceClothesActions.Contains(previousAction))
                 {
                     var npc = __instance.GetNPC();
+
+                    // If leaving a special scene (e.g. lunch), maintain clothes from scene.
+                    if (npc.IsExitingScene()) return;
                     var effectsController = GetEffectController(npc.heroine);
                     if (effectsController == null) return;
 

--- a/KK_SkinEffects/Hooks.PersistClothes.cs
+++ b/KK_SkinEffects/Hooks.PersistClothes.cs
@@ -16,7 +16,7 @@ namespace KK_SkinEffects
         /// </summary>
         private static class PersistClothes
         {
-            [HarmonyPrefix]
+            [HarmonyPostfix]
             [HarmonyPatch(typeof(TalkScene), "TalkEnd")]
             public static void PreTalkSceneEndHook()
             {

--- a/KK_SkinEffects/SkinEffectsController.cs
+++ b/KK_SkinEffects/SkinEffectsController.cs
@@ -100,7 +100,7 @@ namespace KK_SkinEffects
             get => _clothingState;
             set
             {
-                if (_clothingState != value)
+                if (_clothingState != value || _clothingState == null)
                 {
                     _clothingState = value;
 
@@ -114,7 +114,7 @@ namespace KK_SkinEffects
             get => _accessoryState;
             set
             {
-                if (_accessoryState != value)
+                if (_accessoryState != value || _accessoryState == null)
                 {
                     _accessoryState = value;
                     UpdateAccessoryState();
@@ -127,7 +127,7 @@ namespace KK_SkinEffects
             get => _siruState;
             set
             {
-                if (_siruState != value)
+                if (_siruState != value || _siruState == null)
                 {
                     _siruState = value;
                     UpdateSiruState();

--- a/KK_SkinEffects/Utils.cs
+++ b/KK_SkinEffects/Utils.cs
@@ -61,5 +61,14 @@ namespace KK_SkinEffects
             var di = dicTarget[npc.heroine];
             return Traverse.Create(di).Field("_queueAction").GetValue<Queue<int>>();
         }
+
+        /// <summary>
+        /// Returns whether the NPC is exiting a scene
+        /// </summary>
+        public static bool IsExitingScene(this NPC npc)
+        {
+            // A guess that seems to work. 
+            return npc.isActive;
+        }
     }
 }


### PR DESCRIPTION
See commits. Was hard to reliably reproduce, but I think before, talking to a girl right after a shower/clothing change would cause clothes to disappear. This shouldn't happen anymore.

The last remaining "bug" I'm aware of is that after talking to a girl or even an H scene, sometimes girls can decide to change outfits (action 1) which clears the clothing state. Not totally sure if that's a bug, or how to fix it if it is.