### PR TITLE
Preload textures in VR H scenes

### DIFF
--- a/KK_SkinEffects/SkinEffectsPlugin.cs
+++ b/KK_SkinEffects/SkinEffectsPlugin.cs
@@ -61,7 +61,7 @@ namespace KK_SkinEffects
                 SceneManager.sceneLoaded += (scene, mode) =>
                 {
                     // Preload effects for H scene in case they didn't get loaded yet to prevent freeze on first effect appearing
-                    if (scene.name == "H")
+                    if (scene.name == "H" || scene.name == "VRHScene")
                         TextureLoader.PreloadAllTextures();
                 };
             }


### PR DESCRIPTION
In VR mode there is no scene called "H". There is one called "VRHScene", which seems to be the same thing (it's loaded right before the map). Preloading textures at this scene fixed the lagging issue mentioned in the comment.